### PR TITLE
run_tests.js receives test data over stdin and returns results over stdout

### DIFF
--- a/Common/Product/SharedProject/ProcessOutput.cs
+++ b/Common/Product/SharedProject/ProcessOutput.cs
@@ -424,7 +424,7 @@ namespace Microsoft.VisualStudioTools.Project {
                 if (_process.StartInfo.RedirectStandardInput) {
                     // Close standard input so that we don't get stuck trying to read input from the user.
                     try {
-                        _process.StandardInput.Close();
+                        //_process.StandardInput.Close();
                     } catch (InvalidOperationException) {
                         // StandardInput not available
                     }
@@ -496,6 +496,19 @@ namespace Microsoft.VisualStudioTools.Project {
         public string Arguments {
             get {
                 return _arguments;
+            }
+        }
+
+        /// <summary>
+        /// TODO
+        /// </summary>
+        public StreamWriter StandardInput {
+            get
+            {
+                if (_process == null) {
+                    return null;
+                }
+                return _process.StandardInput;
             }
         }
 

--- a/Common/Product/SharedProject/ProcessOutput.cs
+++ b/Common/Product/SharedProject/ProcessOutput.cs
@@ -415,10 +415,10 @@ namespace Microsoft.VisualStudioTools.Project {
 
             if (_process != null) {
                 if (_process.StartInfo.RedirectStandardOutput) {
-                    _process.BeginOutputReadLine();
+                    //_process.BeginOutputReadLine();
                 }
                 if (_process.StartInfo.RedirectStandardError) {
-                    _process.BeginErrorReadLine();
+                    //_process.BeginErrorReadLine();
                 }
                 
                 if (_process.StartInfo.RedirectStandardInput) {
@@ -509,6 +509,20 @@ namespace Microsoft.VisualStudioTools.Project {
                     return null;
                 }
                 return _process.StandardInput;
+            }
+        }
+
+        /// <summary>
+        /// TODO
+        /// </summary>
+        public StreamReader StandardOutput {
+            get
+            {
+                if(_process == null || !_process.StartInfo.RedirectStandardOutput || _process.StartInfo.UseShellExecute) {
+                    return null;
+                }
+
+                return _process.StandardOutput;
             }
         }
 

--- a/Common/Product/SharedProject/ProcessOutput.cs
+++ b/Common/Product/SharedProject/ProcessOutput.cs
@@ -500,7 +500,8 @@ namespace Microsoft.VisualStudioTools.Project {
         }
 
         /// <summary>
-        /// TODO
+        /// The StandardInput stream of the process or null if the process hasn't
+        /// started yet.
         /// </summary>
         public StreamWriter StandardInput {
             get
@@ -513,7 +514,8 @@ namespace Microsoft.VisualStudioTools.Project {
         }
 
         /// <summary>
-        /// TODO
+        /// The StandardOutput stream of the process or null if process hasn't started
+        /// or if conditions are not correct to use the stream.
         /// </summary>
         public StreamReader StandardOutput {
             get

--- a/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
@@ -6,24 +6,6 @@ var result = {
     "stdOut": "",
     "stdErr": ""
 };
-var rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout
-});
-
-try {
-    framework = require('./' + process.argv[2] + '/' + process.argv[2] + '.js');
-} catch (exception) {
-    console.log("NTVS_ERROR:Failed to load TestFramework (" + process.argv[2] + "), " + exception);
-    process.exit(1);
-}
-
-rl.on('line', (line) => {
-    var data = JSON.parse(line);
-    console.log(JSON.stringify(data));
-    result.title = data.testName.replace(' ', '::');
-    framework.run_tests(data.testName, data.testFile, data.workingFolder, data.projectFolder);
-});
 
 process.stdout.write = (function (write) {
     return function (string, encoding, fileDescriptor) {
@@ -38,6 +20,29 @@ process.stderr.write = (function (write) {
         write.apply(process.stderr, arguments);
     };
 })(process.stderr.write);
+
+var rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+});
+
+rl.on('line', (line) => {
+    var data = JSON.parse(line);
+    result.title = data.testName.replace(' ', '::');
+    // get rid of leftover quotations from C#
+    for(var s in data) {
+        data[s] = data[s].replace(/['"]+/g, '');
+    }
+    // run the test
+    framework.run_tests(data.testName, data.testFile, data.workingFolder, data.projectFolder);
+});
+
+try {
+    framework = require('./' + process.argv[2] + '/' + process.argv[2] + '.js');
+} catch (exception) {
+    console.log("NTVS_ERROR:Failed to load TestFramework (" + process.argv[2] + "), " + exception);
+    process.exit(1);
+}
 
 process.on('exit', (code) => {
     result.passed = code === 0 ? true : false;

--- a/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
@@ -1,10 +1,29 @@
 var framework;
+var readline = require('readline');
 var result = {
     "title": "",
     "passed": false,
     "stdOut": "",
     "stdErr": ""
 };
+var rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+});
+
+try {
+    framework = require('./' + process.argv[2] + '/' + process.argv[2] + '.js');
+} catch (exception) {
+    console.log("NTVS_ERROR:Failed to load TestFramework (" + process.argv[2] + "), " + exception);
+    process.exit(1);
+}
+
+rl.on('line', (line) => {
+    var data = JSON.parse(line);
+    console.log(JSON.stringify(data));
+    result.title = data.testName.replace(' ', '::');
+    framework.run_tests(data.testName, data.testFile, data.workingFolder, data.projectFolder);
+});
 
 process.stdout.write = (function (write) {
     return function (string, encoding, fileDescriptor) {
@@ -20,18 +39,10 @@ process.stderr.write = (function (write) {
     };
 })(process.stderr.write);
 
-try {
-    framework = require('./' + process.argv[2] + '/' + process.argv[2] + '.js');
-} catch (exception) {
-    console.log("NTVS_ERROR:Failed to load TestFramework (" + process.argv[2] + "), " + exception);
-    process.exit(1);
-}
-
 process.on('exit', (code) => {
     result.passed = code === 0 ? true : false;
     console.log(JSON.stringify(result));
+    // clear stdOut and stdErr
+    result.stdErr = "";
+    result.stdOut = "";
 });
-
-result.title = process.argv[3].replace(' ', '::');
-
-framework.run_tests(process.argv[3], process.argv[4], process.argv[5], process.argv[6]);

--- a/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
@@ -1,4 +1,25 @@
 var framework;
+var result = {
+    "title": "",
+    "passed": false,
+    "stdOut": "",
+    "stdErr": ""
+};
+
+process.stdout.write = (function (write) {
+    return function (string, encoding, fileDescriptor) {
+        result.stdOut += string;
+        write.apply(process.stdout, arguments);
+    };
+})(process.stdout.write);
+
+process.stderr.write = (function (write) {
+    return function (string, encoding, fileDescriptor) {
+        result.stdErr += string;
+        write.apply(process.stderr, arguments);
+    };
+})(process.stderr.write);
+
 try {
     framework = require('./' + process.argv[2] + '/' + process.argv[2] + '.js');
 } catch (exception) {
@@ -6,5 +27,11 @@ try {
     process.exit(1);
 }
 
-framework.run_tests(process.argv[3], process.argv[4], process.argv[5], process.argv[6]);
+process.on('exit', (code) => {
+    result.passed = code === 0 ? true : false;
+    console.log(JSON.stringify(result));
+});
 
+result.title = process.argv[3].replace(' ', '::');
+
+framework.run_tests(process.argv[3], process.argv[4], process.argv[5], process.argv[6]);

--- a/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
+++ b/Nodejs/Product/Nodejs/TestFrameworks/run_tests.js
@@ -27,22 +27,22 @@ var rl = readline.createInterface({
 });
 
 rl.on('line', (line) => {
-    var data = JSON.parse(line);
-    result.title = data.testName.replace(' ', '::');
+    var testInfo = JSON.parse(line);
+    result.title = testInfo.testName.replace(' ', '::');
     // get rid of leftover quotations from C#
-    for(var s in data) {
-        data[s] = data[s].replace(/['"]+/g, '');
+    for(var s in testInfo) {
+        testInfo[s] = testInfo[s].replace(/['"]+/g, '');
+    }
+
+    try {
+        framework = require('./' + testInfo.framework + '/' + testInfo.framework + '.js');
+    } catch (exception) {
+        console.log("NTVS_ERROR:Failed to load TestFramework (" + process.argv[2] + "), " + exception);
+        process.exit(1);
     }
     // run the test
-    framework.run_tests(data.testName, data.testFile, data.workingFolder, data.projectFolder);
+    framework.run_tests(testInfo.testName, testInfo.testFile, testInfo.workingFolder, testInfo.projectFolder);
 });
-
-try {
-    framework = require('./' + process.argv[2] + '/' + process.argv[2] + '.js');
-} catch (exception) {
-    console.log("NTVS_ERROR:Failed to load TestFramework (" + process.argv[2] + "), " + exception);
-    process.exit(1);
-}
 
 process.on('exit', (code) => {
     result.passed = code === 0 ? true : false;

--- a/Nodejs/Product/TestAdapter/TestExecutor.cs
+++ b/Nodejs/Product/TestAdapter/TestExecutor.cs
@@ -206,7 +206,7 @@ namespace Microsoft.NodejsTools.TestAdapter {
                 frameworkHandle.SendMessage(TestMessageLevel.Informational, _nodeProcess.Arguments);
 #endif
                 // send test to run_tests.js
-                TestCaseObject testObject = new TestCaseObject(args[2], args[3], args[4], args[5]);
+                TestCaseObject testObject = new TestCaseObject(args[1], args[2], args[3], args[4], args[5]);
                 _nodeProcess.StandardInput.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(testObject));
 
                 _nodeProcess.Wait(TimeSpan.FromMilliseconds(500));
@@ -335,18 +335,21 @@ namespace Microsoft.NodejsTools.TestAdapter {
 
         class TestCaseObject {
             public TestCaseObject() {
+                framework = String.Empty;
                 testName = String.Empty;
                 testFile = String.Empty;
                 workingFolder = String.Empty;
                 projectFolder = String.Empty;
             }
 
-            public TestCaseObject(string testName, string testFile, string workingFolder, string projectFolder) {
+            public TestCaseObject(string framework, string testName, string testFile, string workingFolder, string projectFolder) {
+                this.framework = framework;
                 this.testName = testName;
                 this.testFile = testFile;
                 this.workingFolder = workingFolder;
                 this.projectFolder = projectFolder;
             }
+            public string framework { get; set; }
             public string testName { get; set; }
             public string testFile { get; set; }
             public string workingFolder { get; set; }


### PR DESCRIPTION
@mjbvz
`TestExecutor` and `run_tests.js` now communicate via JSON objects sent over standard IO.

In order to redirect and use StandardOutput property of the process, I had to disable the test output the async redirection put in place by `ProcessOutput`. This is not ideal as I'd rather not change the functionality of any objects as they stand-- any ideas on how to get around this issue? I suppose I could use `Process` instead, but there are some nice methods baked into `ProcessOutput` that I'd like to be able to use.

The next step will be to run multiple tests with a single node instance. Once we do this, we won't be able to use process exit code to determine if a test passed or failed... Would a good option be to parse stdout messages from the testing framework to determine pass or fail? Alternatively, I suppose I could pass the `result` object from `run_tests.js` to the `run_tests` of the specific framework, and have that fill out `result.passed` and return that over stdout. Let me know what you think.

Also, I think I originally set up this whole pull-request thing in a very inefficient way (working on `master` and merging into a feature branch is... bad 😿 ) . If it's not too much trouble, I think it might be easier to submit PRs incrementally against a `test-adapter` branch on the original `nodejstools` repo-- which was your original suggestion. Could you help facilitate this?

Please let me know if there are any areas where I should take a second look or improve. 
Thanks so much.